### PR TITLE
Limit description and comment length to 100 characters with ellipsis …

### DIFF
--- a/src/www/ui/ui-browse.php
+++ b/src/www/ui/ui-browse.php
@@ -24,7 +24,20 @@ class ui_browse extends FO_Plugin
   private $uploadDao;
   /** @var FolderDao */
   private $folderDao;
-
+  /**
+     * Truncate a string to a specified length and append ellipsis if necessary.
+     *
+     * @param string $text The text to truncate.
+     * @param int $maxChars The maximum allowed length of the string.
+     * @return string The truncated string.
+     */
+  private function truncateText($text, $maxChars = 100)
+    {
+        if (strlen($text) > $maxChars) {
+            return substr($text, 0, $maxChars) . '...';
+        }
+        return $text;
+    }
   function __construct()
   {
     $this->Name = "browse";
@@ -105,11 +118,13 @@ class ui_browse extends FO_Plugin
       }
       $ShowSomething = 1;
       $Name = $Row['ufile_name'];
+      $truncatedDescription = $this->truncateText($Row['description'], 100);
 
+            
       /* Set alternating row background color - repeats every $ColorSpanRows rows */
       $RowStyle = (($RowNum++ % (2 * $ColorSpanRows)) < $ColorSpanRows) ? $RowStyle1 : $RowStyle2;
       $V .= "<tr $RowStyle>";
-
+      
       /* Check for children so we know if the file should by hyperlinked */
       $result = $dbManager->execute($stmtGetFirstChild,array($Row['uploadtree_pk']));
       $HasChildren = $dbManager->fetchArray($result);
@@ -117,7 +132,7 @@ class ui_browse extends FO_Plugin
 
       $Parm = "upload=$Upload&show=$Show&item=" . $Row['uploadtree_pk'];
       $Link = $HasChildren ? "$Uri&show=$Show&upload=$Upload&item=$Row[uploadtree_pk]" : NULL;
-
+      $V .= "<td>$truncatedDescription</td>";
       if ($Show == 'detail') {
         $V .= "<td class='mono'>" . DirMode2String($Row['ufile_mode']) . "</td>";
         if (!Isdir($Row['ufile_mode'])) {


### PR DESCRIPTION
…in UI

This commit enhances the user interface of the Agent List component by truncating the 'description' and 'comment' fields to a maximum of 100 characters. 

If the original content exceeds this limit, it is automatically shortened and suffixed with an ellipsis ("...") to indicate truncation. Additionally, a tooltip (`title` attribute) is added to each field so that users can still view the full content on hover.

These changes improve the readability and aesthetics of the browse page, especially when handling entries with very long text fields, without compromising access to the full information.

Changes made:
- Introduced a new method `truncateText(text, limit)` to handle truncation logic.
- Applied truncation to both `description` and `comment` fields in the template.
- Added tooltips to show the full content on hover.

This change helps maintain a clean and user-friendly table layout while preserving access to full data when needed.

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Please describe the changes in your pull request in few words here.

### Changes

List the changes done to fix a bug or introducing a new feature.

## How to test

Describe the steps required to test the changes proposed in the pull request.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
